### PR TITLE
Fix input text area height for ISSUE-3

### DIFF
--- a/RoboTF_LLM_Token_Estimator.py
+++ b/RoboTF_LLM_Token_Estimator.py
@@ -80,7 +80,7 @@ def main():
         # Text input for the model name
         model_name = st.text_area(
             "Enter the Hugging Face model name: (org/model_name)",
-            placeholder="mistralai/Mistral-7B-Instruct-v0.3", height=10  # Default model name
+            placeholder="mistralai/Mistral-7B-Instruct-v0.3", height=68  # Default model name
         )
 
         # Text area for the user's input text

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,7 +1,7 @@
 version: "3"
 
 vars:
-  IMAGE_VERSION: "v0.0.2"
+  IMAGE_VERSION: "v0.0.3"
   IMAGE_NAME: "robotf/robotf-llm-token-estimator"
 
 tasks:

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
     "name": "robotf-llm-token-estimator",
-    "version": "v0.0.2"
+    "version": "v0.0.3"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-streamlit==1.37.1
-streamlit_extras==0.4.0
+streamlit==1.41.1
+streamlit_extras==0.5.0
 streamlit_js_eval==0.1.7
-emoji==2.14.0
-extra_streamlit_components==0.1.70
-autotiktokenizer==0.2.1
+emoji==2.14.1
+extra_streamlit_components==0.1.71
+autotiktokenizer==0.2.2


### PR DESCRIPTION
Fix input text area height for [ISSUE-3](https://github.com/kkacsh321/robotf-llm-token-estimator/issues/3)

Updating the following packages:
streamlit==1.41.1
streamlit_extras==0.5.0
emoji==2.14.1
extra_streamlit_components==0.1.71
autotiktokenizer==0.2.2